### PR TITLE
Add combat control for initiative on systems with initiative

### DIFF
--- a/lancer-initiative.js
+++ b/lancer-initiative.js
@@ -67,6 +67,14 @@ function registerSettings() {
     type: Boolean,
     default: false,
   });
+  game.settings.register("lancer-initiative", "enable-initiative", {
+    name: game.i18n.localize("LANCERINITIATIVE.EnableInitiative"),
+    hint: game.i18n.localize("LANCERINITIATIVE.EnableInitiativeDesc"),
+    scope: "world",
+    config: !!CONFIG.Combat.initiative.formula,
+    type: Boolean,
+    default: false,
+  });
 
   // Override classes
   CONFIG.Combat.entityClass = LancerCombat;

--- a/lang/en.json
+++ b/lang/en.json
@@ -16,6 +16,8 @@
   "LANCERINITIATIVE.ActivatedLastDesc": "Moves units that have taken their turn to the end of the tracker.",
   "LANCERINITIATIVE.SortTracker": "Sort the Tracker",
   "LANCERINITIATIVE.SortTrackerDesc": "Moves the unit currently taking their turn to the top of the tracker and moves units that have taken their turn to the end of the tracker.",
+  "LANCERINITIATIVE.EnableInitiative": "Enable Initiative Rolling",
+  "LANCERINITIATIVE.EnableInitiativeDesc": "Adds a button to owned combatants for rolling initiative",
   "LANCERINITIATIVE.AddActivation": "Add Activation",
   "LANCERINITIATIVE.RemoveActivation": "Remove Activation",
   "LANCERINITIATIVE.UndoActivation": "Undo Activation"

--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
     "description": "Implements Lancer's popcorn style initiative in Foundry VTT",
     "author": "Bolts",
     "type": "module",
-    "version": "0.3.3-dev",
+    "version": "0.4.4-dev",
     "minimumCoreVersion": "0.7.0",
     "compatibleCoreVersion": "0.7.9",
     "esmodules": [

--- a/module/lancer-combat-tracker.js
+++ b/module/lancer-combat-tracker.js
@@ -81,7 +81,7 @@ export class LancerCombatTracker extends CombatTracker {
    * renderCombatTracker event
    * @static
    */
-  static handleRender(_, html, data) {
+  static handleRender(app, html, data) {
     const options = {
       friendly: game.settings.get("lancer-initiative", "pc-col"),
       neutral: game.settings.get("lancer-initiative", "nu-col"),
@@ -89,6 +89,7 @@ export class LancerCombatTracker extends CombatTracker {
       inactive: game.settings.get("lancer-initiative", "xx-col"),
       icon: game.settings.get("lancer-initiative", "icon"),
       icon_size: game.settings.get("lancer-initiative", "icon-size").toString() + "rem",
+      enable_initiative: game.settings.get("lancer-initiative", "enable-initiative"),
     };
     html.find(".combatant").each((_, element) => {
       const c_id = element.dataset.combatantId;
@@ -134,6 +135,23 @@ export class LancerCombatTracker extends CombatTracker {
       init_div.addEventListener("click", async _ => {
         await data.combat.activateCombatant(c_id);
       });
+
+      // This may be removed in a future update. It definitely needs a
+      // clean-up.
+      if (
+        options.enable_initiative &&
+        combatant.permission === ENTITY_PERMISSIONS.OWNER &&
+        combatant.initiative === null
+      ) {
+        let init_button = document.createElement("a");
+        init_button.classList.add("combatant-control");
+        init_button.setAttribute("title", game.i18n.localize("COMBAT.InitiativeRoll"));
+        init_button.setAttribute("data-control", "rollInitiative");
+        init_button.innerHTML = `<i class="fas fa-dice-d20"></i>`;
+        init_button.addEventListener("click", async e => app._onCombatantControl(e));
+        const controls = element.getElementsByClassName("combatant-controls")[0];
+        controls.insertAdjacentElement("afterbegin", init_button);
+      }
     });
   }
 }


### PR DESCRIPTION
If CONFIG.Combat.initiative.formula isn't null add a rollInitiative
button next to the controls for visibility and defeated status. 

Ref #8 