### PR TITLE
Use global.d.ts for type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "devDependencies": {
-    "@league-of-foundry-developers/foundry-vtt-types": "^0.7.9-6",
+    "@types/jquery": "^3.5.5",
     "prettier": "^2.3.0",
     "typescript": "^4.3.2"
   },

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,4 +1,5 @@
 import { LancerCombatTracker } from "./module/lancer-combat-tracker";
+import "jquery";
 
 declare global {
   namespace ClientSettings {
@@ -9,22 +10,169 @@ declare global {
     }
   }
 
-  export class Combatant {
-    data: object;
-    get actor(): Actor | null;
+  interface Math {
+    clamped(n: numebr, min: number, max: number): number;
+  }
+
+  var game: {
+    combats: any;
+    i18n: {
+      localize(key: string): string;
+    };
+    settings: {
+      get(scope: string, key: string): unknown;
+      set(scope: string, key: string, value: unknown): Promise<void>;
+      register(
+        scope: string,
+        name: string,
+        data: {
+          name?: string;
+          hint?: string;
+          scope: string;
+          config: boolean;
+          type: unknown;
+          default?: unknown;
+          onChange?: (...args: any) => void;
+        }
+      ): void;
+      registerMenu(
+        scope: string,
+        name: string,
+        data: {
+          name?: string;
+          label?: string;
+          type: unknown;
+          restricted?: boolean;
+        }
+      ): void;
+    };
+    system: {
+      id: string;
+    };
+    user: User | null;
+  };
+
+  var CONFIG: {
+    Combat: {
+      documentClass: new (...args: any) => Combat;
+      initiative: {
+        formula: string | null;
+      };
+    };
+    Combatant: {
+      documentClass: new (...args: any) => Combatant;
+    };
+    time: {
+      turnTime: number;
+      roundTime: number;
+    };
+    ui: {
+      combat: new (...args: any) => CombatTracker;
+    };
+  };
+
+  /**
+   * A simple event framework used throughout Foundry Virtual Tabletop.
+   * When key actions or events occur, a "hook" is defined where user-defined callback functions can execute.
+   * This class manages the registration and execution of hooked callback functions.
+   */
+  export class Hooks {
+    /**
+     * Call all hook listeners in the order in which they were registered
+     * Hooks called this way can not be handled by returning false and will always trigger every hook callback.
+     *
+     * @param hook - The hook being triggered
+     * @param args - Arguments passed to the hook callback functions
+     * @returns Were all hooks called without execution being prevented?
+     */
+    static callAll(hook: string, ...args: any): true;
+    /**
+     * Register a callback handler for an event which is only triggered once the first time the event occurs.
+     * After a "once" hook is triggered the hook is automatically removed.
+     *
+     * @param hook - The unique name of the hooked event
+     * @param fn   - The callback function which should be triggered when the hook event occurs
+     * @return An ID number of the hooked function which can be used to turn off the hook later
+     */
+    static once(hook: string, fn: (...args: any) => void | boolean): number;
+  }
+
+  class ClientDocument {
+    data: {
+      update(data: object, context?: object): unknown;
+      [x: string]: any;
+    };
+    parent: ClientDocument | null;
+
+    get id(): string;
+
     testUserPermission(user: User, permission: string, options?: unknown): boolean;
-
-    get isVisible(): boolean;
-
-    protected _onCreate(data: Record<string, any>, options: unknown, user: User): void;
-    protected _preCreate(data: Record<string, any>, options: unknown, user: User): Promise<void>;
-
+    toObject(): object;
+    protected _onCreate(data: this["data"], options: unknown, user: User): void;
+    protected _preCreate(data: this["data"], options: unknown, user: User): Promise<void>;
     setFlag(scope: string, key: string, value: unknown): Promise<this>;
-    getFlag(scope: string, key: string): any;
+    getFlag(scope: string, key: string): unknown;
 
     update(data: Record<string, unknown>, options?: Record<string, unknown>): Promise<this>;
+
+    getEmbeddedDocument(document: string, id: string): ClientDocument | undefined;
+    updateEmbeddedDocuments(
+      document: string,
+      data: ClientDocument["data"][]
+    ): Promise<ClientDocument[]>;
 
     prepareBaseData(): void;
     prepareDerivedData(): void;
   }
+
+  export class Combat extends ClientDocument {
+    turns: Combatant[];
+    get combatants(): Combatant[];
+    get combatant(): Combatant;
+    get round(): number;
+    protected _sortCombatants(a: Combatant, b: Combatant): number;
+
+    getEmbeddedDocument(document: "Combatant", id: string): Combatant | undefiend;
+
+    startCombat(): Promise<this>;
+    nextRound(): Promise<this>;
+    previousRound(): Promise<this>;
+    resetAll(): Promise<this>;
+  }
+
+  export class Combatant extends ClientDocument {
+    parent: Combat | null;
+    get actor(): Actor | null;
+    get token(): Token | null;
+
+    get isVisible(): boolean;
+  }
+
+  export class User extends ClientDocument {
+    get isGM(): boolean;
+  }
+
+  export class CombatTracker {
+    viewed: Combat | null;
+
+    get combats(): Combat[];
+
+    getData(options: unknown): Promise<object>;
+    activateListeners(html: JQuery<HTMLElement>): void;
+
+    protected _renderInner(data: object): Promise<JQuery<HTMLElement>>;
+    protected _getEntryContextOptions(): {
+      name: string;
+      icon: string;
+      callback: (...args: any) => unknown;
+    }[];
+  }
+
+  class FormApplication {
+    static get defaultOptions(): object;
+    activateListeners(html: JQuery<HTMLElement>): void;
+    render(): void;
+  }
+
+  function diffObject(a: object, b: object, options: object): object;
 }

--- a/src/lancer-initiative.ts
+++ b/src/lancer-initiative.ts
@@ -92,11 +92,8 @@ function registerSettings(): void {
   });
 
   // Override classes
-  // @ts-ignore 0.8
   CONFIG.Combat.documentClass = LancerCombat;
-  // @ts-ignore 0.8
   CONFIG.Combatant.documentClass = LancerCombatant;
-  // @ts-ignore 0.8
   CONFIG.ui.combat = LancerCombatTracker;
 
   // Call hooks for initialization of Lancer Initiative

--- a/src/module/li-form.ts
+++ b/src/module/li-form.ts
@@ -5,9 +5,9 @@ type Appearance = typeof LancerCombatTracker.appearance
  * Settings form for customizing the icon appearance of the icon used in the
  * tracker
  */
-export class LIForm extends FormApplication<FormApplication.Options, Appearance> {
+export class LIForm extends FormApplication {
   /** @override */
-  static get defaultOptions(): FormApplication.Options {
+  static get defaultOptions(): object {
     return {
       ...super.defaultOptions,
       title: "Lancer Intiative",

--- a/tsconfig.foundry.json
+++ b/tsconfig.foundry.json
@@ -4,7 +4,7 @@
     "outDir": "./lancer-initiative/",
     "sourceMap": true,
     "lib": ["ES6", "ES2017", "DOM"],
-    "types": ["@league-of-foundry-developers/foundry-vtt-types"],
+    "types": [],
     "moduleResolution": "node",
     "strict": true,
     "skipLibCheck": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "es6",
     "sourceMap": true,
     "lib": ["ES6", "ES2017", "DOM"],
-    "types": ["@league-of-foundry-developers/foundry-vtt-types"],
+    "types": [],
     "moduleResolution": "node",
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Temporarily (hopefully) removes foundry-vtt-types as a dependency and
defines the parts of the foundry API that are used directly in
global.d.ts so as to eliminate excessive @ts-ignore annotations. This
will ideally provide a smoother transition to the 0.8.x series of
foundry-vtt-types when it becomes available.