### PR TITLE
Initial Star Wars FFG compatibility.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,14 @@ const config = {
     dir: "dist",
     format: "es",
     sourcemap: true,
+    chunkFileNames: chunkInfo => {
+      switch (chunkInfo.name) {
+        case "starwarsffg":
+          return "[name].js";
+        default:
+          return "[name]-[hash].js";
+      }
+    },
     plugins: [
       terser({ keep_classnames: true, keep_fnames: true }),
     ],

--- a/src/add_interfaces.js
+++ b/src/add_interfaces.js
@@ -1,0 +1,41 @@
+/**
+ * Manually insert the overridden methods from LancerCombat into the passed
+ * class
+ */
+export function add_combat_interface(system_combat_class) {
+  const LancerCombat = CONFIG.Combat.documentClass;
+  class CustomLancerCombat extends system_combat_class {}
+
+  Object.getOwnPropertyNames(LancerCombat.prototype)
+    .filter(n => n !== "constructor")
+    .forEach(method =>
+      Object.defineProperty(
+        CustomLancerCombat.prototype,
+        method,
+        Object.getOwnPropertyDescriptor(LancerCombat.prototype, method)
+      )
+    );
+
+  return CustomLancerCombat;
+}
+
+/**
+ * Manually insert the overridden methods from LancerCombatant into the passed
+ * class
+ */
+export function add_combatant_interface(system_combatant_class) {
+  const LancerCombatant = CONFIG.Combatant.documentClass;
+  class CustomLancerCombatant extends system_combatant_class {}
+
+  Object.getOwnPropertyNames(LancerCombatant.prototype)
+    .filter(n => n !== "constructor")
+    .forEach(method =>
+      Object.defineProperty(
+        CustomLancerCombatant.prototype,
+        method,
+        Object.getOwnPropertyDescriptor(LancerCombatant.prototype, method)
+      )
+    );
+
+  return CustomLancerCombatant;
+}

--- a/src/lancer-initiative.ts
+++ b/src/lancer-initiative.ts
@@ -39,10 +39,20 @@ function registerSettings(): void {
   });
   Object.defineProperty(CONFIG.LancerInitiative, "module", { writable: false });
 
+  const old_combat = CONFIG.Combat.documentClass;
+
+  // Override classes
+  CONFIG.Combat.documentClass = LancerCombat;
+  CONFIG.Combatant.documentClass = LancerCombatant;
+  CONFIG.ui.combat = LancerCombatTracker;
+
   switch (game.system.id) {
     case "lancer":
       config.def_appearance.icon = "cci cci-activate";
       config.def_appearance.icon_size = 2;
+      break;
+    case "starwarsffg":
+      import("./starwarsffg").then(m => m.setup(old_combat));
       break;
     default:
   }
@@ -85,11 +95,6 @@ function registerSettings(): void {
     module,
     "combat-tracker-enable-initiative"
   );
-
-  // Override classes
-  CONFIG.Combat.documentClass = LancerCombat;
-  CONFIG.Combatant.documentClass = LancerCombatant;
-  CONFIG.ui.combat = LancerCombatTracker;
 
   // Call hooks to signal other modules of the initialization
   Hooks.callAll("LancerInitiativeInit");

--- a/src/starwarsffg.d.ts
+++ b/src/starwarsffg.d.ts
@@ -1,0 +1,1 @@
+export function setup(combat_class: typeof Combat): void;

--- a/src/starwarsffg.js
+++ b/src/starwarsffg.js
@@ -1,0 +1,8 @@
+import { add_combat_interface } from "./add_interfaces";
+
+export function setup(combat_class) {
+  console.log(`${CONFIG.LancerInitiative.module} | Setting up starwarsffg integration`);
+
+  const LancerCombatFFG = add_combat_interface(combat_class);
+  CONFIG.Combat.documentClass = LancerCombatFFG;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "outDir": "./dist/",
-    "module": "es6",
+    "module": "es2020",
     "sourceMap": true,
     "inlineSources": true,
     "lib": ["ES6", "ES2017", "DOM"],


### PR DESCRIPTION
Use the base FFG combat class to create a mixin. As of right now, it's
not working, as the rollInitiative method from CombatFFG assumes that
there is always an active combatant and that turn is never null. I
should be able to submit a small patch to the system to fix that issue.
