### PR TITLE
Enable sorting by default.

### DIFF
--- a/src/lancer-initiative.ts
+++ b/src/lancer-initiative.ts
@@ -72,7 +72,7 @@ function registerSettings(): void {
     config: true,
     type: Boolean,
     onChange: () => game.combats?.render(),
-    default: false,
+    default: true,
   });
   // Allows initiative rolling to be toggled. Optional for downstreams.
   game.settings.register(module, "combat-tracker-enable-initiative", {


### PR DESCRIPTION
Off by default was a legacy choice due to an obsolete bug. The option
may be entirely removed in the future.
