### PR TITLE
Restore legacy compatibility fields to prevent v9 hosts from installing

### DIFF
--- a/public/module.json
+++ b/public/module.json
@@ -6,10 +6,12 @@
     "authors": [{ "name": "Bolts" }],
     "type": "module",
     "version": "24-dev",
+    "compatibleCoreVersion": "10.284",
+    "minimumCoreVersion": "10",
     "compatibility": {
-        "minimum": 10,
+        "minimum": "10",
         "verified": "10.284",
-        "maximum": 10
+        "maximum": "10"
     },
     "esmodules": ["./lancer-initiative.js"],
     "styles": ["./lancer-initiative.css"],


### PR DESCRIPTION
I don't know how long these fields will be necessary, but likely until
v12 releases.
