### PR TITLE
chore(curb): upgrade maximum version to 11

### DIFF
--- a/public/module.json
+++ b/public/module.json
@@ -8,7 +8,7 @@
     "compatibility": {
         "minimum": "10",
         "verified": "10.284",
-        "maximum": "10"
+        "maximum": "11"
     },
     "esmodules": ["./lancer-initiative.js"],
     "styles": ["./lancer-initiative.css"],


### PR DESCRIPTION
# Summary
Lancer initiative is reported to work well with version 11. This PR bumps maximum version of Foundry to 11.

Fixes #37